### PR TITLE
PThreadVC2.dll installer fix

### DIFF
--- a/external/liblo.pri
+++ b/external/liblo.pri
@@ -8,6 +8,7 @@ clebsCheck(liblo) {
         isEmpty(LIBLOLIBDIR_RELEASE):LIBLOLIBDIR_RELEASE = $${LIBLOLIBDIR}/ReleaseDLL
         isEmpty(LIBLOLIBDIR_DEBUG):LIBLOLIBDIR_DEBUG = $${LIBLOLIBDIR}/DebugDLL
         isEmpty(LIBLOINCLUDEDIR):LIBLOINCLUDEDIR = $${LIBLOROOT}
+        isEmpty(LIBLOPTHREADDIR):LIBLOPTHREADDIR = $${LIBLOROOT}/pthreads-w32-2-9-1-release/Pre-built.2/dll/x86
 
         exists($${LIBLOROOT}):CLEBS_DEPENDENCIES *= liblo
     }
@@ -36,10 +37,16 @@ clebsInstall(liblo) {
     win32 {
         CONFIG(debug, debug|release) {
             libloinstall.files = $${LIBLOLIBDIR_DEBUG}/$${LIBLOLIB_DEBUG}.dll
+            pthreadinstall.files = $${LIBLOPTHREADDIR}/pthreadVC2.dll
         } else {
             libloinstall.files = $${LIBLOLIBDIR_RELEASE}/$${LIBLOLIB_RELEASE}.dll
+            pthreadinstall.files = $${LIBLOPTHREADDIR}/pthreadVC2.dll
         }
+
         libloinstall.path = $$BINDIR
-        INSTALLS *= libloinstall
+        pthreadinstall.path = $$BINDIR
+
+        INSTALLS += libloinstall pthreadinstall
+
     }
 }


### PR DESCRIPTION
Pluginloader failed when loading osccontroller.dll , which uses vs2010 liblo, a simple OSC messaging library. This seemed to be due to a missing dependency called PThreadVC2.dll. Upon further inspection it seemed like only the main lib dll was added to install via clebs system. This fix adds the correct directory with the needed lib pthreadvc2.dll.